### PR TITLE
Develop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,14 +15,16 @@
 		"ms-iot.vscode-ros"
 	],
 	"runArgs": [
-        	"--rm",
-        	"--network",
-        	"host"
-    	],
-    	"mounts": [
-        	"source=vscode-server-extension,target=/home/sonia/.vscode-server/extensions,type=volume"
-    	],
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined",
+		"--rm",
+		"--network",
+		"host"
+	],
+	"mounts": [
+		"source=vscode-server-extension,target=/home/sonia/.vscode-server/extensions,type=volume"
+	],
 	"workspaceMount": "target=/home/sonia/ros_sonia_ws/src/proc_hydrophone,type=volume",
 	"workspaceFolder": "/home/sonia/ros_sonia_ws/src/proc_hydrophone"
 }
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/home/sonia/base_lib_ws/devel/lib/python2.7/dist-packages",
+        "/opt/ros/melodic/lib/python2.7/dist-packages"
+    ]
+}

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>proc_hydrophone</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
     The proc_hydrophone is responsible process data received from provider_hydrophone.
   </description>


### PR DESCRIPTION
## Description
 - Add additional `settings.json` to resolve python container in remote debuging
 - Add ptrace arguments to `devcontainer.json` to grant full access in container to cpp debugger  

## How has this been tested ?
Locally tested with vscode remote-container and ROS extensions

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings